### PR TITLE
Add a new verification into Prompt for Groq

### DIFF
--- a/src/integrations/groq/GroqSpamChecker.ts
+++ b/src/integrations/groq/GroqSpamChecker.ts
@@ -2,7 +2,7 @@ import Groq from 'groq-sdk';
 import { SimpleRequestBody, SpamChecker, SpamCheckResult } from '../../SpamChecker';
 
 // It tells the model to response with 1 if the email is spam, phishing, or illegitimate and 0 if it is not
-const PROMPT = '"Determine whether the following email is spam, phishing, or illegitimate. If it is, respond only with 1. If it is not spam, respond only with 0. Do not include any explanations or additional text. Note: We are an association of computer science students and are not interested in purchasing any products or services."'
+const PROMPT = '"Determine whether the following email is spam, phishing, or illegitimate. If it is, respond only with 1. If it is not spam, respond only with 0. Do not include any explanations or additional text. Note: We are an association of computer science students and are not interested in purchasing any products, services or software."'
 
 export class GroqSpamChecker extends SpamChecker {
 


### PR DESCRIPTION
This pull request includes a minor update to the `GroqSpamChecker` class in the `src/integrations/groq/GroqSpamChecker.ts` file. The change modifies the `PROMPT` constant to clarify that the association is not interested in purchasing any software, in addition to products and services.

* [`src/integrations/groq/GroqSpamChecker.ts`](diffhunk://#diff-d0ecb6d925e638c0253bb3fd72ae5c86cdfe75635d08bc0677cc61d5318f369cL5-R5): Updated the `PROMPT` constant to specify that the association is not interested in purchasing any software.… offers